### PR TITLE
feat : [임보경] 회원가입 컴포넌트 분리 및 토스트 UI 추가[SLIDE-TO-PUSH7]

### DIFF
--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/controller/member/MemberController.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/controller/member/MemberController.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import slide_to_push_backend.controller.member.form.MemberSignInForm;
+import slide_to_push_backend.controller.member.form.MemberRegisterForm;
 import slide_to_push_backend.service.member.MemberService;
 
 @Slf4j
@@ -21,5 +22,11 @@ public class MemberController {
         return service.signIn(form.toMemberSignInRequest());
     }
 
+    @PostMapping("/sign-up")
+    public Boolean memberRegister (@RequestBody MemberRegisterForm form) {
+        log.info("memberRegister(): " + form);
+
+        return service.signUp(form.toMemberRegisterRequest());
+    }
 
 }

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/controller/member/MemberController.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/controller/member/MemberController.java
@@ -22,6 +22,14 @@ public class MemberController {
         return service.signIn(form.toMemberSignInRequest());
     }
 
+    @PostMapping("/check-email/{email}")
+    public Boolean emailValidation(@PathVariable("email")  String email) {
+        log.info("emailValidation(): " + email);
+        String tmp = service.emailValidation(email).toString();
+
+        log.info(tmp);
+        return service.emailValidation(email);
+    }
     @PostMapping("/sign-up")
     public Boolean memberRegister (@RequestBody MemberRegisterForm form) {
         log.info("memberRegister(): " + form);

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/controller/member/form/MemberRegisterForm.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/controller/member/form/MemberRegisterForm.java
@@ -1,0 +1,19 @@
+package slide_to_push_backend.controller.member.form;
+
+import lombok.*;
+import slide_to_push_backend.service.member.request.MemberRegisterRequest;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MemberRegisterForm {
+
+    public MemberRegisterRequest toMemberRegisterRequest;
+    String nickName;
+    String email;
+    String password;
+
+    public MemberRegisterRequest toMemberRegisterRequest () {
+        return new MemberRegisterRequest(nickName, email, password);
+    }
+}

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/entity/member/Account.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/entity/member/Account.java
@@ -1,5 +1,6 @@
 package slide_to_push_backend.entity.member;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,9 +22,17 @@ public class Account {
     @Column(nullable = false)
     private String email;
 
+    @OneToOne(mappedBy = "account", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    private AccountProfile profile;
 
     @OneToMany(mappedBy = "account", fetch = FetchType.LAZY)
     private Set<Authentication> authentications = new HashSet<>();
+
+    public Account(String email, AccountProfile profile) {
+        this.email = email;
+        this.profile = profile;
+        profile.setAccount(this);
+    }
 
     public boolean isRightPassword(String plainToCheck) {
         final Optional<Authentication> maybeBasicAuth = findBasicAuthentication();

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/entity/member/AccountProfile.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/entity/member/AccountProfile.java
@@ -1,0 +1,34 @@
+package slide_to_push_backend.entity.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+
+@Entity
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccountProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id = null;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    @Getter
+    @Column(nullable = false)
+    private String nickName;
+
+    public AccountProfile(String nickName) { this.nickName = nickName; }
+
+    public void setAccount (Account account) {
+        this.account = account;
+    }
+
+}

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/MemberService.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/MemberService.java
@@ -1,9 +1,12 @@
 package slide_to_push_backend.service.member;
 
+import slide_to_push_backend.service.member.request.MemberRegisterRequest;
 import slide_to_push_backend.service.member.request.MemberSignInRequest;
 
 public interface MemberService {
 
     String signIn(MemberSignInRequest request);
+    Boolean signUp(MemberRegisterRequest registerRequest);
+
 }
 

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/MemberService.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/MemberService.java
@@ -6,6 +6,7 @@ import slide_to_push_backend.service.member.request.MemberSignInRequest;
 public interface MemberService {
 
     String signIn(MemberSignInRequest request);
+    Boolean emailValidation(String email);
     Boolean signUp(MemberRegisterRequest registerRequest);
 
 }

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/MemberServiceImpl.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/MemberServiceImpl.java
@@ -4,8 +4,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import slide_to_push_backend.entity.member.Account;
+import slide_to_push_backend.entity.member.Authentication;
+import slide_to_push_backend.entity.member.BasicAuthentication;
 import slide_to_push_backend.repository.member.AccountRepository;
 import slide_to_push_backend.repository.member.AuthenticationRepository;
+import slide_to_push_backend.service.member.request.MemberRegisterRequest;
 import slide_to_push_backend.service.member.request.MemberSignInRequest;
 import slide_to_push_backend.service.security.RedisService;
 
@@ -18,27 +21,28 @@ public class MemberServiceImpl implements MemberService{
 
     @Autowired
     private AccountRepository accountRepository;
-
     @Autowired
     private RedisService redisService;
+    @Autowired
+    private AuthenticationRepository authenticationRepository;
+    @Override
+    public Boolean signUp(MemberRegisterRequest request) {
+        final Account account = request.toMember();
+        accountRepository.save(account);
+
+        final BasicAuthentication auth = new BasicAuthentication(account,
+                Authentication.BASIC_AUTH, request.getPassword());
+
+        authenticationRepository.save(auth);
+
+        return true;
+    }
 
     @Override
     public String signIn(MemberSignInRequest request) {
         String email = request.getEmail();
         Optional<Account> maybeMember = accountRepository.findByEmail(email);
-/*
-        public Board read(Long boardNo) {
-            Optional<Board> maybeBoard = repository.findById(boardNo);
 
-            if (maybeBoard.equals(Optional.empty())) {
-                log.info("Can't read board!!!");
-                return null;
-            }
-
-            return maybeBoard.get();
-
-        }
-  */
         if (maybeMember.isPresent()) {
             Account account = maybeMember.get();
 

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/MemberServiceImpl.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/MemberServiceImpl.java
@@ -26,6 +26,16 @@ public class MemberServiceImpl implements MemberService{
     @Autowired
     private AuthenticationRepository authenticationRepository;
     @Override
+    public Boolean emailValidation(String email) {
+        Optional<Account> maybeMember = accountRepository.findByEmail(email);
+
+        if (maybeMember.isPresent()) {
+            return false;
+        }
+
+        return true;
+    }
+    @Override
     public Boolean signUp(MemberRegisterRequest request) {
         final Account account = request.toMember();
         accountRepository.save(account);
@@ -37,7 +47,6 @@ public class MemberServiceImpl implements MemberService{
 
         return true;
     }
-
     @Override
     public String signIn(MemberSignInRequest request) {
         String email = request.getEmail();

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/request/MemberRegisterRequest.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/request/MemberRegisterRequest.java
@@ -1,0 +1,23 @@
+package slide_to_push_backend.service.member.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import slide_to_push_backend.entity.member.Account;
+import slide_to_push_backend.entity.member.AccountProfile;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class MemberRegisterRequest {
+    String nickName;
+    String email;
+    String password;
+
+    public Account toMember () {
+        AccountProfile profile = new AccountProfile(nickName);
+        return new Account(email, profile);
+    }
+}

--- a/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/request/MemberRegisterRequest.java
+++ b/p4th/BokyeongLim/slide_to_push_backend/src/main/java/slide_to_push_backend/service/member/request/MemberRegisterRequest.java
@@ -1,6 +1,5 @@
 package slide_to_push_backend.service.member.request;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
@@ -10,11 +9,10 @@ import slide_to_push_backend.entity.member.AccountProfile;
 @Getter
 @ToString
 @RequiredArgsConstructor
-@AllArgsConstructor
 public class MemberRegisterRequest {
-    String nickName;
-    String email;
-    String password;
+    private final String nickName;
+    private final String email;
+    private final String password;
 
     public Account toMember () {
         AccountProfile profile = new AccountProfile(nickName);

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/api/http_service_api.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/api/http_service_api.dart
@@ -1,0 +1,24 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+class HttpService {
+  static const String httpUri = '10.0.2.2:9955';
+  static var resEmailValidation;
+  emailValidation(String email) async {
+    var data = {'email': email};
+    var body = json.encode(data);
+
+    try{
+      resEmailValidation = await http.post(
+        Uri.http(httpUri, '/member/check-email/$email'),
+        headers: {"Content-Type": "application/json"},
+        body: body,
+      );
+
+    }catch (e){
+      debugPrint(e.toString());
+    }
+  }
+}

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/api/spring_api.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/api/spring_api.dart
@@ -23,6 +23,33 @@ class SpringApi {
 
     return SignInResponse(true);
   }
+  Future<SignUpResponse>signUp (SignUpRequest signUpRequest) async {
+    var data = { 'nickName': signUpRequest.nickName, 'email': signUpRequest.email, 'password': signUpRequest.password };
+    var body = json.encode(data);
+
+    debugPrint("body:" + body); // json형태로 encoding 확인
+
+    final response = await http.post(
+      Uri.http(httpUri, '/member/sign-up'),
+      headers: {"Content-Type" : "application/json"},
+      body: body,
+    );
+
+    return SignUpResponse(true);
+  }
+}
+
+
+class SignUpResponse {
+  bool? success;
+  SignUpResponse(this.success);
+}
+
+class SignUpRequest {
+  String nickName;
+  String email;
+  String password;
+  SignUpRequest(this.nickName, this.email, this.password);
 }
 
 class SignInResponse {

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/checkBox_field.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/checkBox_field.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+class CheckBoxField extends StatefulWidget {
+  final String title;
+
+  const CheckBoxField({
+    Key? key,
+    required this.title,
+  }) : super(key: key);
+
+  static bool isChecked = false;
+  @override
+  State<CheckBoxField> createState() => _CheckBoxFieldState();
+}
+
+class _CheckBoxFieldState extends State<CheckBoxField> {
+
+  var title = '';
+
+  @override
+  void initState() {
+    super.initState();
+    title = widget.title;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return CheckboxListTile(
+      title: Text(title),
+      controlAffinity: ListTileControlAffinity.leading, //checkbox at left
+      value: CheckBoxField.isChecked,
+      onChanged: (bool? value) {
+      setState(() {
+        CheckBoxField.isChecked = value!;
+      });
+      },
+    );
+  }
+}

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_checked_password.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_checked_password.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:slide_to_push_frontend/utility/decoration.dart';
+
+
+
+class TextFieldCheckedPassword extends StatefulWidget {
+  const TextFieldCheckedPassword({Key? key}) : super(key: key);
+
+  static String checkedPassword = '';
+
+  @override
+  State<TextFieldCheckedPassword> createState() => _TextFieldCheckedPasswordState();
+}
+
+class _TextFieldCheckedPasswordState extends State<TextFieldCheckedPassword> {
+
+  FocusNode _checkedPasswordFocus = new FocusNode();
+  var textFieldStyle = textFormDecoration('다시 한번 password를 입력해주세요.');
+
+  @override
+  Widget build(BuildContext context) {
+
+    return TextFormField(
+      decoration: textFieldStyle,
+      keyboardType: TextInputType.visiblePassword,
+      focusNode:_checkedPasswordFocus,
+      autovalidateMode: AutovalidateMode.onUserInteraction,
+      // validator: (value) =>
+      // TextFieldPassword.password == checkedPassword ? '틀렸습니다.' : null,
+      obscureText: true,
+      onSaved: (value) {
+        setState(() {
+          TextFieldCheckedPassword.checkedPassword = value!;
+        });
+      },
+    );
+  }
+
+}
+

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_common.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_common.dart
@@ -5,9 +5,13 @@ import '../../utility/input_validate.dart';
 
 
 class TextFieldCommon extends StatefulWidget {
-  TextFieldCommon({Key? key}) : super(key: key);
+  final String formName;
+  static String enteredMessage = '';
 
-  static String message = '';
+  TextFieldCommon({
+    Key? key,
+    required this.formName,
+  }) : super(key: key);
 
   @override
   State<TextFieldCommon> createState() => _TextFieldCommonState();
@@ -15,18 +19,27 @@ class TextFieldCommon extends StatefulWidget {
 
 class _TextFieldCommonState extends State<TextFieldCommon> {
 
-  FocusNode _nickNameFocus = new FocusNode();
+  var formName = '';
+
+  @override
+  void initState() {
+    super.initState();
+    formName = widget.formName;
+  }
+
+  FocusNode _thisTextFieldFocus = new FocusNode();
+
   @override
   Widget build(BuildContext context) {
     return TextFormField(
-      decoration:textFormDecoration("닉네임을 입력해주세요." ),
+      decoration:textFormDecoration('$formName 입력해주세요.'),
       keyboardType: TextInputType.emailAddress,
-      focusNode:_nickNameFocus,
-      validator: (value) => CheckValidate().validateText(_nickNameFocus, value!),
+      focusNode:_thisTextFieldFocus,
+      validator: (value) => CheckValidate().validateText(_thisTextFieldFocus, value!),
       autovalidateMode: AutovalidateMode.onUserInteraction,
       onSaved: (value) {
         setState(() {
-          TextFieldCommon.message = value!;
+          TextFieldCommon.enteredMessage = value!;
         });
       },
     );

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_email.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_email.dart
@@ -4,9 +4,12 @@ import '../../utility/input_validate.dart';
 
 
 class TextFieldEmail extends StatefulWidget {
-  const TextFieldEmail({Key? key}) : super(key: key);
+  final TextEditingController controller;
 
-  static String email = '';
+  TextFieldEmail({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
 
   @override
   State<TextFieldEmail> createState() => _TextFieldEmailState();
@@ -14,23 +17,38 @@ class TextFieldEmail extends StatefulWidget {
 
 class _TextFieldEmailState extends State<TextFieldEmail> {
 
-  FocusNode _emailFocus = new FocusNode();
+  late FocusNode emailFocus;
   var textFieldStyle = textFormDecoration('email을 입력해주세요.');
+  var controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = widget.controller;
+    emailFocus = FocusNode();
+  }
+
+  @override
+  void dispose() {
+    emailFocus.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-
     return TextFormField(
+      controller: controller,
       decoration: textFieldStyle,
       keyboardType: TextInputType.emailAddress,
-      focusNode:_emailFocus,
-      validator: (value) => CheckValidate().validateEmail(_emailFocus, value!),
+      focusNode:emailFocus,
+      validator: (value) => CheckValidate().validateEmail(emailFocus, value!),
       autovalidateMode: AutovalidateMode.onUserInteraction,
       onSaved: (value) {
         setState(() {
-          TextFieldEmail.email = value!;
+          controller.text = value;
         });
       },
+      // onChanged: (value) => setState(()=> controller.text = value)
     );
   }
 

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_nickName.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_nickName.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:slide_to_push_frontend/utility/decoration.dart';
+
+import '../../utility/input_validate.dart';
+
+
+class TextFieldCommon extends StatefulWidget {
+  TextFieldCommon({Key? key}) : super(key: key);
+
+  static String message = '';
+
+  @override
+  State<TextFieldCommon> createState() => _TextFieldCommonState();
+}
+
+class _TextFieldCommonState extends State<TextFieldCommon> {
+
+  FocusNode _nickNameFocus = new FocusNode();
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      decoration:textFormDecoration("닉네임을 입력해주세요." ),
+      keyboardType: TextInputType.emailAddress,
+      focusNode:_nickNameFocus,
+      validator: (value) => CheckValidate().validateText(_nickNameFocus, value!),
+      autovalidateMode: AutovalidateMode.onUserInteraction,
+      onSaved: (value) {
+        setState(() {
+          TextFieldCommon.message = value!;
+        });
+      },
+    );
+  }
+}
+
+

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_password.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/inputs/text_field_password.dart
@@ -22,7 +22,7 @@ class _TextFieldPasswordState extends State<TextFieldPassword> {
 
     return TextFormField(
       decoration: textFieldStyle,
-      keyboardType: TextInputType.emailAddress,
+      keyboardType: TextInputType.visiblePassword,
       focusNode:_passwordFocus,
       autovalidateMode: AutovalidateMode.onUserInteraction,
       validator: (value) => CheckValidate().validatePassword(_passwordFocus, value!),

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_in_form.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_in_form.dart
@@ -17,16 +17,29 @@ class SignInForm extends StatefulWidget {
 }
 
 class _SignInFormState extends State<SignInForm> {
+  late TextEditingController emailEditController;
+
+  @override
+  void initState() {
+    super.initState();
+    emailEditController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    emailEditController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-
-    GlobalKey<FormState> formkey = GlobalKey<FormState>();
+    GlobalKey<FormState> formKey = GlobalKey<FormState>();
 
     return Form(
-        key: formkey,
+        key: formKey,
         child: Column(
           children: [
-            TextFieldEmail(),
+            TextFieldEmail(controller: emailEditController,),
             SizedBox(height: medium_gap),
             TextFieldPassword(),
             SizedBox(height: medium_gap),
@@ -50,8 +63,8 @@ class _SignInFormState extends State<SignInForm> {
             SizedBox(height: medium_gap),
             ElevatedButton(
               onPressed:(){
-                formkey.currentState?.save();
-                SpringApi().signIn(SignInRequest(TextFieldEmail.email, TextFieldPassword.password));
+                formKey.currentState?.save();
+                SpringApi().signIn(SignInRequest(emailEditController.text, TextFieldPassword.password));
               },
               child:Text("SIGN IN", style: TextStyle(color: Colors.white,)),
               style: Buttons.defaultButton,

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_in_form.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_in_form.dart
@@ -4,6 +4,7 @@ import 'package:slide_to_push_frontend/components/inputs/text_field_email.dart';
 import 'package:slide_to_push_frontend/components/inputs/text_field_password.dart';
 
 import 'package:slide_to_push_frontend/utility/buttons.dart';
+import 'package:slide_to_push_frontend/utility/routes.dart';
 import 'package:slide_to_push_frontend/utility/size.dart';
 
 import 'package:slide_to_push_frontend/api/spring_api.dart';
@@ -21,7 +22,6 @@ class _SignInFormState extends State<SignInForm> {
 
     GlobalKey<FormState> formkey = GlobalKey<FormState>();
 
-
     return Form(
         key: formkey,
         child: Column(
@@ -34,7 +34,9 @@ class _SignInFormState extends State<SignInForm> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 TextButton(
-                  onPressed: (){},
+                  onPressed: (){
+                    Navigator.of(context).pushNamed(Routes.signUp);
+                  },
                   child: Text('SIGN UP'),
                   style: Buttons.defaultTextButton,
                 ),

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_up_form.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_up_form.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:fluttertoast/fluttertoast.dart';
-import 'package:slide_to_push_frontend/api/spring_api.dart';
-import 'package:slide_to_push_frontend/components/inputs/text_field_common.dart';
+import 'package:slide_to_push_frontend/components/inputs/text_field_nickName.dart';
 import 'package:slide_to_push_frontend/components/inputs/text_field_email.dart';
 import 'package:slide_to_push_frontend/components/inputs/text_field_password.dart';
 import 'package:slide_to_push_frontend/components/inputs/text_field_checked_password.dart';
@@ -10,6 +8,7 @@ import 'package:slide_to_push_frontend/utility/buttons.dart';
 import 'package:slide_to_push_frontend/utility/color.dart';
 import 'package:slide_to_push_frontend/utility/size.dart';
 
+import '../api/http_service_api.dart';
 import 'inputs/checkBox_field.dart';
 
 class SignUpForm extends StatefulWidget {
@@ -21,8 +20,40 @@ class SignUpForm extends StatefulWidget {
 
 class _SignUpFormState extends State<SignUpForm> {
 
-  String firstPassword = TextFieldPassword.password;
-  String secondPassword = TextFieldCheckedPassword.checkedPassword;
+  late TextEditingController emailEditController;
+  bool isButtonActive = true;
+
+  @override
+  void initState() {
+    super.initState();
+    emailEditController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    emailEditController.dispose();
+    super.dispose();
+  }
+
+  checkAccountEmail(String email) async{
+    await HttpService().emailValidation(email);
+    if(HttpService.resEmailValidation.statusCode == 200) {
+      var responseBody = jsonDecode(HttpService.resEmailValidation.body);
+      debugPrint(responseBody.toString());
+
+      if(responseBody == true) {
+        debugPrint("프론트로 넘어옴");
+        setState(() {
+          isButtonActive = false;
+        });
+      } else {
+        alertNotAvailable();
+        setState(() {
+          isButtonActive = true;
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -33,12 +64,26 @@ class _SignUpFormState extends State<SignUpForm> {
           children: [
             TextFieldCommon(formName: '닉네임'),
             SizedBox(height: medium_gap),
-            TextFieldEmail(),
+            TextFieldEmail(controller: emailEditController,),
             SizedBox(height: small_gap),
             ElevatedButton(
-              onPressed: (){} ,
-              child: Text("이메일 중복 체크",style: TextStyle(color: ColorPicker.defaultBlack)),
-              style: Buttons.subButton2,
+              onPressed: isButtonActive
+                ? (){
+                if(emailEditController.text.isNotEmpty) {
+                  checkAccountEmail(emailEditController.text);
+                }
+
+                if(emailEditController.text.isEmpty) {
+                  alertEnterEmail();
+                  setState(() {
+                    isButtonActive = true;
+                  });
+                }
+
+              }
+              : null,
+              child: Text("이메일 중복 체크"),
+              style: Buttons.subLongButton,
             ),
             SizedBox(height: medium_gap),
             TextFieldPassword(),
@@ -62,7 +107,7 @@ class _SignUpFormState extends State<SignUpForm> {
                 } else {
                   SpringApi().signUp(SignUpRequest(
                       TextFieldCommon.enteredMessage,
-                      TextFieldEmail.email,
+                      emailEditController.text,
                       TextFieldPassword.password
                   ));
                 }
@@ -80,10 +125,27 @@ class _SignUpFormState extends State<SignUpForm> {
         )
     );
   }
+
 }
 
 int compareToString(String msg1, String msg2){
   return msg1.compareTo(msg2);
+}
+
+void alertNotAvailable() {
+  Fluttertoast.showToast(
+    msg:"중복된 이메일입니다.",
+    gravity: ToastGravity.TOP,
+    toastLength: Toast.LENGTH_SHORT,
+  );
+}
+
+void alertEnterEmail() {
+  Fluttertoast.showToast(
+    msg:"이메일을 입력해주세요.",
+    gravity: ToastGravity.TOP,
+    toastLength: Toast.LENGTH_SHORT,
+  );
 }
 
 void failDueToUnchecked() {

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_up_form.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_up_form.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:slide_to_push_frontend/components/inputs/text_field_nickName.dart';
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:slide_to_push_frontend/api/spring_api.dart';
+import 'package:slide_to_push_frontend/components/inputs/text_field_common.dart';
 import 'package:slide_to_push_frontend/components/inputs/text_field_email.dart';
 import 'package:slide_to_push_frontend/components/inputs/text_field_password.dart';
 import 'package:slide_to_push_frontend/components/inputs/text_field_checked_password.dart';
@@ -8,7 +10,7 @@ import 'package:slide_to_push_frontend/utility/buttons.dart';
 import 'package:slide_to_push_frontend/utility/color.dart';
 import 'package:slide_to_push_frontend/utility/size.dart';
 
-
+import 'inputs/checkBox_field.dart';
 
 class SignUpForm extends StatefulWidget {
   const SignUpForm({Key? key}) : super(key: key);
@@ -19,7 +21,8 @@ class SignUpForm extends StatefulWidget {
 
 class _SignUpFormState extends State<SignUpForm> {
 
-  bool _isChecked = false;
+  String firstPassword = TextFieldPassword.password;
+  String secondPassword = TextFieldCheckedPassword.checkedPassword;
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +31,7 @@ class _SignUpFormState extends State<SignUpForm> {
         key: formKey,
         child: Column(
           children: [
-            TextFieldCommon(),
+            TextFieldCommon(formName: '닉네임'),
             SizedBox(height: medium_gap),
             TextFieldEmail(),
             SizedBox(height: small_gap),
@@ -42,26 +45,26 @@ class _SignUpFormState extends State<SignUpForm> {
             SizedBox(height: medium_gap),
             TextFieldCheckedPassword(),
             SizedBox(height: small_gap),
-            Row(
-              children: <Widget>[
-                Checkbox(
-                    value: _isChecked,
-                    onChanged: (value){
-                      setState(() {
-                        _isChecked = value!;
-                      });
-                    }
-                ),
-                SizedBox(width: small_gap),
-                Text('이용약관에 동의하십니까?')
-              ],
-            ),
+            CheckBoxField(title: '이용약관에 동의하십니까?'),
             SizedBox(height: small_gap),
             ElevatedButton(
               onPressed:(){
-                if(TextFieldPassword.password == TextFieldCheckedPassword.checkedPassword){
-                  formKey.currentState?.save();
-                  debugPrint(TextFieldPassword.password + TextFieldCheckedPassword.checkedPassword + "체크");
+                formKey.currentState?.save();
+                int tmp = compareToString(TextFieldPassword.password,TextFieldCheckedPassword.checkedPassword);
+
+                // debugPrint(TextFieldPassword.password + " "+TextFieldCheckedPassword.checkedPassword );
+                // debugPrint('$tmp');
+
+                if(tmp != 0) {
+                  failDueToPasswordError();
+                } else if (CheckBoxField.isChecked == false) {
+                  failDueToUnchecked();
+                } else {
+                  SpringApi().signUp(SignUpRequest(
+                      TextFieldCommon.enteredMessage,
+                      TextFieldEmail.email,
+                      TextFieldPassword.password
+                  ));
                 }
               },
               child:Text("SIGN UP", style: TextStyle(color: Colors.white,)),
@@ -77,4 +80,24 @@ class _SignUpFormState extends State<SignUpForm> {
         )
     );
   }
+}
+
+int compareToString(String msg1, String msg2){
+  return msg1.compareTo(msg2);
+}
+
+void failDueToUnchecked() {
+  Fluttertoast.showToast(
+    msg:"이용약관에 동의해주세요.",
+    gravity: ToastGravity.TOP,
+    toastLength: Toast.LENGTH_SHORT,
+  );
+}
+
+void failDueToPasswordError() {
+  Fluttertoast.showToast(
+    msg:"비밀번호를 확인해주세요.",
+    gravity: ToastGravity.TOP,
+    toastLength: Toast.LENGTH_SHORT,
+  );
 }

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_up_form.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/components/sign_up_form.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:slide_to_push_frontend/components/inputs/text_field_nickName.dart';
+import 'package:slide_to_push_frontend/components/inputs/text_field_email.dart';
+import 'package:slide_to_push_frontend/components/inputs/text_field_password.dart';
+import 'package:slide_to_push_frontend/components/inputs/text_field_checked_password.dart';
+
+import 'package:slide_to_push_frontend/utility/buttons.dart';
+import 'package:slide_to_push_frontend/utility/color.dart';
+import 'package:slide_to_push_frontend/utility/size.dart';
+
+
+
+class SignUpForm extends StatefulWidget {
+  const SignUpForm({Key? key}) : super(key: key);
+
+  @override
+  State<SignUpForm> createState() => _SignUpFormState();
+}
+
+class _SignUpFormState extends State<SignUpForm> {
+
+  bool _isChecked = false;
+
+  @override
+  Widget build(BuildContext context) {
+    GlobalKey<FormState> formKey = GlobalKey<FormState>();
+    return Form(
+        key: formKey,
+        child: Column(
+          children: [
+            TextFieldCommon(),
+            SizedBox(height: medium_gap),
+            TextFieldEmail(),
+            SizedBox(height: small_gap),
+            ElevatedButton(
+              onPressed: (){} ,
+              child: Text("이메일 중복 체크",style: TextStyle(color: ColorPicker.defaultBlack)),
+              style: Buttons.subButton2,
+            ),
+            SizedBox(height: medium_gap),
+            TextFieldPassword(),
+            SizedBox(height: medium_gap),
+            TextFieldCheckedPassword(),
+            SizedBox(height: small_gap),
+            Row(
+              children: <Widget>[
+                Checkbox(
+                    value: _isChecked,
+                    onChanged: (value){
+                      setState(() {
+                        _isChecked = value!;
+                      });
+                    }
+                ),
+                SizedBox(width: small_gap),
+                Text('이용약관에 동의하십니까?')
+              ],
+            ),
+            SizedBox(height: small_gap),
+            ElevatedButton(
+              onPressed:(){
+                if(TextFieldPassword.password == TextFieldCheckedPassword.checkedPassword){
+                  formKey.currentState?.save();
+                  debugPrint(TextFieldPassword.password + TextFieldCheckedPassword.checkedPassword + "체크");
+                }
+              },
+              child:Text("SIGN UP", style: TextStyle(color: Colors.white,)),
+              style: Buttons.defaultButton,
+            ),
+            SizedBox(height: medium_gap),
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: Text('Back', style:TextStyle(color: ColorPicker.subTextButton, fontSize: 18)),
+              style: Buttons.defaultTextButton,
+            )
+          ],
+        )
+    );
+  }
+}

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/main.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:slide_to_push_frontend/utility/color.dart';
-import 'package:slide_to_push_frontend/view/sign_in_view.dart';
+import 'package:slide_to_push_frontend/utility/routes.dart';
+
 
 void main() {
   runApp(const MyApp());
@@ -13,15 +14,14 @@ class MyApp extends StatelessWidget {
 
     return MaterialApp(
       title: 'Slide to Push',
-        theme: ThemeData(
-          fontFamily: 'AppleSDGothicNeo',
-          scaffoldBackgroundColor: ColorPicker.defaultBackground,
-        ),
+      routes: Routes.routes,
+      theme: ThemeData(
+        fontFamily: 'AppleSDGothicNeo',
+        scaffoldBackgroundColor: ColorPicker.defaultBackground,
+      ),
 
-        initialRoute: "/sign_in",
-        routes: {
-          "/sign_in": (context) => SignInView()
-        },
+      initialRoute: "/sign_in",
+
     );
 
 

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/buttons.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/buttons.dart
@@ -8,40 +8,19 @@ class Buttons {
   Buttons._();
 
   static ButtonStyle get defaultButton => ElevatedButton.styleFrom(
+    elevation: 0.0,
+    shadowColor: Colors.transparent,
     textStyle: TextStyle(
       fontFamily: 'AppleSDGothicNeoH',
       fontWeight: FontWeight.w800,
       fontSize: 15,
       color: Colors.white,
     ),
+
     primary: ColorPicker.defaultBlack,
     onPrimary: Colors.black,
     shape: ContinuousRectangleBorder(),
     minimumSize: Size(400, 60),
-  );
-  static ButtonStyle get defaultButtonH => ElevatedButton.styleFrom(
-    textStyle: TextStyle(
-      fontFamily: 'AppleSDGothicNeoH',
-      fontWeight: FontWeight.w800,
-      fontSize: 15,
-      color: Colors.white,
-    ),
-    primary: ColorPicker.defaultBlack,
-    onPrimary: Colors.black,
-    shape: ContinuousRectangleBorder(),
-    minimumSize: Size(160, 60),
-  );
-
-  static ButtonStyle get subButton => ElevatedButton.styleFrom(
-    textStyle: TextStyle(
-      fontFamily: 'AppleSDGothicNeoH',
-      fontWeight: FontWeight.w800,
-      fontSize: 15,
-    ),
-    primary: ColorPicker.subBackground,
-    onPrimary: Colors.black,
-    shape: ContinuousRectangleBorder(),
-    minimumSize: Size(120, 60),
   );
 
   static ButtonStyle get defaultTextButton => TextButton.styleFrom(
@@ -51,14 +30,16 @@ class Buttons {
     ),
   );
 
-  static ButtonStyle get subButton2 => ElevatedButton.styleFrom(
+  static ButtonStyle get subLongButton => ElevatedButton.styleFrom(
+    elevation: 0.0,
+    shadowColor: Colors.transparent,
     textStyle: TextStyle(
       fontFamily: 'AppleSDGothicNeoM',
       fontWeight: FontWeight.w400,
     ),
     shape: ContinuousRectangleBorder(),
     primary: ColorPicker.subBackground,
-    onPrimary: Colors.black,
+    onPrimary:  ColorPicker.defaultBlack,
     side: BorderSide(width: 1.0, color: ColorPicker.subTextButton),
     minimumSize: Size(400, 40),
   );

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/buttons.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/buttons.dart
@@ -19,12 +19,48 @@ class Buttons {
     shape: ContinuousRectangleBorder(),
     minimumSize: Size(400, 60),
   );
+  static ButtonStyle get defaultButtonH => ElevatedButton.styleFrom(
+    textStyle: TextStyle(
+      fontFamily: 'AppleSDGothicNeoH',
+      fontWeight: FontWeight.w800,
+      fontSize: 15,
+      color: Colors.white,
+    ),
+    primary: ColorPicker.defaultBlack,
+    onPrimary: Colors.black,
+    shape: ContinuousRectangleBorder(),
+    minimumSize: Size(160, 60),
+  );
+
+  static ButtonStyle get subButton => ElevatedButton.styleFrom(
+    textStyle: TextStyle(
+      fontFamily: 'AppleSDGothicNeoH',
+      fontWeight: FontWeight.w800,
+      fontSize: 15,
+    ),
+    primary: ColorPicker.subBackground,
+    onPrimary: Colors.black,
+    shape: ContinuousRectangleBorder(),
+    minimumSize: Size(120, 60),
+  );
 
   static ButtonStyle get defaultTextButton => TextButton.styleFrom(
     textStyle: TextStyle(
       fontFamily: 'AppleSDGothicNeoB',
       fontWeight: FontWeight.w500,
     ),
+  );
+
+  static ButtonStyle get subButton2 => ElevatedButton.styleFrom(
+    textStyle: TextStyle(
+      fontFamily: 'AppleSDGothicNeoM',
+      fontWeight: FontWeight.w400,
+    ),
+    shape: ContinuousRectangleBorder(),
+    primary: ColorPicker.subBackground,
+    onPrimary: Colors.black,
+    side: BorderSide(width: 1.0, color: ColorPicker.subTextButton),
+    minimumSize: Size(400, 40),
   );
 }
 

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/color.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/color.dart
@@ -3,7 +3,8 @@ import 'package:flutter/painting.dart';
 class ColorPicker {
   static const defaultBlack = Color(0xff292A30);
   static const defaultBackground = Color(0xffF9eee8);
-
+  static const subBackground = Color(0xffd7cdcc);
+  static const subTextButton = Color(0xffb2a6a5);
   static const errorRed = Color(0xffd71b3d);
 
   static const strongPink = Color(0xffffb99f);

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/decoration.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/decoration.dart
@@ -29,7 +29,7 @@ InputDecoration textFormDecoration(hintText) {
   return InputDecoration(
     hintText: hintText,
     contentPadding: const EdgeInsets.symmetric(vertical: 20.0, horizontal: 15.0),
-    // contentPadding: EdgeInsets.fromLTRB(20, 10, 20, 10),
+
     enabledBorder:
     OutlineInputBorder(
         borderRadius: BorderRadius.zero,

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/input_validate.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/input_validate.dart
@@ -2,6 +2,14 @@
 import 'package:flutter/material.dart';
 
 class CheckValidate {
+  String? validateText(FocusNode focusNode, String value) {
+    if(value.isEmpty) {
+      focusNode.requestFocus();
+      return '필수 사항입니다.';
+    } else {
+      return null;
+    }
+  }
   String? validateEmail(FocusNode focusNode, String value) {
     if(value.isEmpty) {
       focusNode.requestFocus();
@@ -14,10 +22,7 @@ class CheckValidate {
     }
   }
   String? validatePassword(FocusNode focusNode, String value) {
-    if(value.isEmpty) {
-      focusNode.requestFocus();
-      return '비밀번호를 입력하세요';
-    } else if(!value.isValidPasswordFormat()) {
+    if(!value.isValidPasswordFormat()) {
       focusNode.requestFocus();
       return '유효하지 않은 비밀번호입니다.';
     } else {

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/routes.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/utility/routes.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/cupertino.dart';
+import 'package:slide_to_push_frontend/view/sign_in_view.dart';
+import 'package:slide_to_push_frontend/view/sign_up_view.dart';
+
+class Routes {
+  Routes._();
+
+  static const String signIn = '/sign_in';
+  static const String signUp = '/sign_up';
+
+  static final routes = <String, WidgetBuilder>{
+    signIn: (BuildContext context) => SignInView(),
+    signUp: (BuildContext context) => SignUpView(),
+
+  };
+}

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/view/sign_in_view.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/view/sign_in_view.dart
@@ -11,12 +11,11 @@ class SignInView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      resizeToAvoidBottomInset : false,
       body: SafeArea(
         child: Container(
-          width: double.infinity,
-          // height: double.infinity,
-          // decoration: defaultContainerLine();,
-          padding: EdgeInsets.all(30),
+            width: double.infinity,
+            padding: EdgeInsets.all(30),
           child: Column(
             children: [
               SizedBox(height: 80),

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/view/sign_in_view.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/view/sign_in_view.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:slide_to_push_frontend/components/sign_in_form.dart';
 import 'package:slide_to_push_frontend/utility/color.dart';
 import 'package:slide_to_push_frontend/utility/size.dart';
@@ -9,15 +8,15 @@ import '../utility/decoration.dart';
 class SignInView extends StatelessWidget {
   SignInView({Key? key}) : super(key: key);
 
-  var containerLine = defaultContainerLine();
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
         child: Container(
           width: double.infinity,
+          // height: double.infinity,
+          // decoration: defaultContainerLine();,
           padding: EdgeInsets.all(30),
-          decoration: containerLine,
           child: Column(
             children: [
               SizedBox(height: 80),

--- a/p4th/BokyeongLim/slide_to_push_frontend/lib/view/sign_up_view.dart
+++ b/p4th/BokyeongLim/slide_to_push_frontend/lib/view/sign_up_view.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:slide_to_push_frontend/components/sign_up_form.dart';
+import 'package:slide_to_push_frontend/utility/color.dart';
+import 'package:slide_to_push_frontend/utility/size.dart';
+
+
+class SignUpView extends StatelessWidget {
+  SignUpView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SingleChildScrollView(
+        child: SafeArea(
+          child: Container(
+              width: double.infinity,
+              // height: MediaQuery.of(context).size.height,
+              // decoration: defaultContainerLine(),
+              padding: EdgeInsets.all(30),
+              child: Column(
+                children: [
+                  SizedBox(height: large_gap),
+                  Container(
+
+                    child: Column(
+                      children:[
+                        Text(
+                          'SIGN - UP',
+                          style: TextStyle(
+                            fontFamily: 'AppleSDGothicNeoH',
+                            fontWeight: FontWeight.w800,
+                            fontSize: 25,
+                            color: ColorPicker.defaultBlack,
+                          ),
+                        ),
+                        SizedBox(height: large_gap),
+                        SignUpForm(),
+                      ],
+                    )
+                  ),
+                ],
+              )
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/p4th/BokyeongLim/slide_to_push_frontend/pubspec.lock
+++ b/p4th/BokyeongLim/slide_to_push_frontend/pubspec.lock
@@ -74,6 +74,18 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fluttertoast:
+    dependency: "direct main"
+    description:
+      name: fluttertoast
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.1.1"
   http:
     dependency: "direct main"
     description:
@@ -88,6 +100,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.2"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3"
   lints:
     dependency: transitive
     description:
@@ -186,3 +205,4 @@ packages:
     version: "2.1.1"
 sdks:
   dart: ">=2.16.1 <3.0.0"
+  flutter: ">=1.10.0"

--- a/p4th/BokyeongLim/slide_to_push_frontend/pubspec.yaml
+++ b/p4th/BokyeongLim/slide_to_push_frontend/pubspec.yaml
@@ -35,13 +35,11 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   http: ^0.13.4
+  fluttertoast: ^8.1.1
 
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-
-
-
 
 dev_dependencies:
   flutter_test:

--- a/p4th/BokyeongLim/slide_to_push_frontend/pubspec.yaml
+++ b/p4th/BokyeongLim/slide_to_push_frontend/pubspec.yaml
@@ -37,9 +37,11 @@ dependencies:
   http: ^0.13.4
   fluttertoast: ^8.1.1
 
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
+
+
+
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
**완료**
[SLIDE-TO-PUSH6]
👌SIGN UP FORM 
👌SIGN UP VIEW 
👌화면 간 이동 ROUTER 설정
👌SingleChildScrollView 사용으로 스크롤링 오류 해결

[SLIDE-TO-PUSH7]
👌공통 컴포넌트 : 
      체크박스 
      기본 텍스트 박스 
      동일한 비밀번호 여부
👌체크 박스 클릭 후 입력한 인풋 초기화 해결
👌비밀번호가 동일하지 않으면 해당 오류 안내하는 토스트 팝업 구현
👌체크 박스 동의하지 않으면 생기는 오류 안내하는 토스트 팝업 구현
👌모든 조건이 충족 된 뒤 api로 데이터 submit할 수 있도록 기능 구현

주말 목표
회원가입 및 로그인 백엔드 구현
가입 실패 오류 프론트에서 사용자에게 안내하는 UI 기능 구현
로그인 실패 시 프론트에서 사용자에게 안내하는 UI 기능 구현
