### PR TITLE
feat : [윤희지] 유효성 검사 통과 못한 text form field 사이의 focus 이슈 해결 [HOME-ALONE3]

### DIFF
--- a/p4th/HeejiYun/frontend/lib/api/spring_member_api.dart
+++ b/p4th/HeejiYun/frontend/lib/api/spring_member_api.dart
@@ -19,9 +19,10 @@ class SpringMemberApi {
 
     if (response.statusCode == 200) {
       debugPrint("통신 확인");
+      return json.decode(response.body);
+    } else {
+      throw Exception("통신 실패");
     }
-
-    return json.decode(response.body);
 
   }
 
@@ -37,9 +38,10 @@ class SpringMemberApi {
 
     if (response.statusCode == 200) {
       debugPrint("통신 확인");
+      return json.decode(response.body);
+    } else {
+      throw Exception("통신 실패");
     }
-
-    return json.decode(response.body);
   }
 
   Future<bool?> signUp (MemberSignUpRequest request) async {
@@ -59,9 +61,10 @@ class SpringMemberApi {
 
     if (response.statusCode == 200) {
       debugPrint("통신 확인");
+      return json.decode(response.body);
+    } else {
+      throw Exception("통신 실패");
     }
-
-    return json.decode(response.body);
   }
 
   Future<SignInResponse> signIn (MemberSignInRequest request) async {
@@ -84,8 +87,7 @@ class SpringMemberApi {
 
       return SignInResponse(response.body);
     } else {
-      debugPrint("통신 실패");
-      return SignInResponse("로그인 실패");
+      throw Exception("통신 실패");
     }
   }
 }

--- a/p4th/HeejiYun/frontend/lib/components/forms/sign_up_form.dart
+++ b/p4th/HeejiYun/frontend/lib/components/forms/sign_up_form.dart
@@ -48,6 +48,9 @@ class SignUpFormState extends State<SignUpForm> {
     emailController.dispose();
     passwordController.dispose();
     nicknameController.dispose();
+    TextFormFieldEmail.emailFocus.dispose();
+    TextFormFieldPassword.passwordFocus.dispose();
+    TextFormFieldNickname.nicknameFocus.dispose();
     super.dispose();
   }
 

--- a/p4th/HeejiYun/frontend/lib/components/text_form_fields/text_form_field_email.dart
+++ b/p4th/HeejiYun/frontend/lib/components/text_form_fields/text_form_field_email.dart
@@ -27,8 +27,7 @@ class _TextFormFieldEmailState extends State<TextFormFieldEmail> {
         TextFormField(
           controller: widget.controller,
           focusNode: TextFormFieldEmail.emailFocus,
-          validator: (value) => CheckValidate().
-          validateEmail(TextFormFieldEmail.emailFocus, value!),
+          validator: (value) => CheckValidate().validateEmail(value!),
           autovalidateMode: AutovalidateMode.onUserInteraction,
           onChanged: (text) {
             form?.emailPass = false;

--- a/p4th/HeejiYun/frontend/lib/components/text_form_fields/text_form_field_nickname.dart
+++ b/p4th/HeejiYun/frontend/lib/components/text_form_fields/text_form_field_nickname.dart
@@ -28,7 +28,7 @@ class _TextFormFieldNicknameState extends State<TextFormFieldNickname> {
           focusNode: TextFormFieldNickname.nicknameFocus,
           controller: widget.controller,
           validator: (value) => CheckValidate().
-          validateNickname(TextFormFieldNickname.nicknameFocus, value!),
+          validateNickname(value!),
           autovalidateMode: AutovalidateMode.onUserInteraction,
           onChanged: (text) {
             form?.nicknamePass = false;

--- a/p4th/HeejiYun/frontend/lib/components/text_form_fields/text_form_field_password.dart
+++ b/p4th/HeejiYun/frontend/lib/components/text_form_fields/text_form_field_password.dart
@@ -7,14 +7,13 @@ import '../../utility/validate.dart';
 class TextFormFieldPassword extends StatefulWidget {
   const TextFormFieldPassword({Key? key, required this.controller}) : super(key: key);
   final TextEditingController controller;
+  static FocusNode passwordFocus = FocusNode();
 
   @override
   State<TextFormFieldPassword> createState() => _TextFormFieldPasswordState();
 }
 
 class _TextFormFieldPasswordState extends State<TextFormFieldPassword> {
-
-  FocusNode _passwordFocus = FocusNode();
 
   @override
   Widget build(BuildContext context) {
@@ -25,9 +24,9 @@ class _TextFormFieldPasswordState extends State<TextFormFieldPassword> {
         const SizedBox(height: small_gap,),
         TextFormField(
           controller: widget.controller,
-          focusNode: _passwordFocus,
+          focusNode: TextFormFieldPassword.passwordFocus,
           obscureText: true,
-          validator: (value) => CheckValidate().validatePassword(_passwordFocus, value!),
+          validator: (value) => CheckValidate().validatePassword(value!),
           autovalidateMode: AutovalidateMode.onUserInteraction,
           decoration: InputDecoration(
             hintText: "Enter password",

--- a/p4th/HeejiYun/frontend/lib/utility/validate.dart
+++ b/p4th/HeejiYun/frontend/lib/utility/validate.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/cupertino.dart';
 
 class CheckValidate{
-  String? validateEmail(FocusNode focusNode, String value){
+  String? validateEmail(String value){
     if(value.isEmpty){
-      focusNode.requestFocus();
       return '이메일을 입력하세요.';
     }else {
       RegExp regExp = RegExp(r'^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$');
       if(!regExp.hasMatch(value)){
-        focusNode.requestFocus();	//포커스를 해당 textformfield에 맞춘다.
         return '잘못된 이메일 형식입니다.';
       }else{
         return null;
@@ -16,14 +14,12 @@ class CheckValidate{
     }
   }
 
-  String? validatePassword(FocusNode focusNode, String value){
+  String? validatePassword(String value){
     if(value.isEmpty){
-      focusNode.requestFocus();
       return '비밀번호를 입력하세요.';
     }else {
       RegExp regExp = RegExp(r'^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,15}$');
       if(!regExp.hasMatch(value)){
-        focusNode.requestFocus();
         return '영문, 숫자 포함 8자 이상 15자 이내로 입력하세요.';
       }else{
         return null;
@@ -31,19 +27,16 @@ class CheckValidate{
     }
   }
 
-  String? validateNickname(FocusNode focusNode, String value){
+  String? validateNickname(String value){
     if(value.isEmpty){
-      focusNode.requestFocus();
       return '닉네임을 입력하세요.';
     }else {
       RegExp regExp = RegExp(r'^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,10}$');
       if(!regExp.hasMatch(value)){
-        focusNode.requestFocus();	//포커스를 해당 textformfield에 맞춘다.
         return '한글, 영문, 숫자로 구성된 2 ~ 10자리 닉네임을 입력하세요.';
       }else{
         return null;
       }
     }
   }
-
 }


### PR DESCRIPTION
validation을 수행하는 메서드의 내부 로직이 원인이었음.

유효성 검사를 통과하지 못하면  focusNode.requestFocus()가 실행되어
유효성 검사를 통과하지 못한 text form field 사이에서 번갈아가면서 포커스를 맞추게 되면서
focus가 계속해서 바뀌는 상황이 발생했던 것 같음.

각각의 vaildate 메서드에서 requestFocus 부분을 삭제해서 해결.
+ 중복 체크에서 focusNode()를 쓰지 않게 되어 parameter를 String만 받는 것으로 변경.